### PR TITLE
Fixing the ubuntu iso download location

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -2,9 +2,9 @@
 BASE_DIR='iso'
 SUB_DIR='nocloud'
 REPO_DIR="$BASE_DIR/$SUB_DIR"
-UBUNTU_MIRROR="https://mirror.pit.teraswitch.com/ubuntu-releases/"
 UBUNTU_VERSION="20.04.1"
-ISO_NAME="ubuntu-20.04.1-live-server-amd64.iso"
+UBUNTU_MIRROR="http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/$UBUNTU_VERSION/release/"
+ISO_NAME="ubuntu-$UBUNTU_VERSION-legacy-server-amd64.iso"
 
 
 function show_help() {
@@ -33,7 +33,7 @@ function install_packages() {
 
 function download_iso() {
     if [ ! -f $ISO_NAME ]; then
-        wget $UBUNTU_MIRROR/$UBUNTU_VERSION/$ISO_NAME
+        wget $UBUNTU_MIRROR/$ISO_NAME
     fi
 }
 


### PR DESCRIPTION
The ubuntu download location was renamed after 20.04.2 was release per #5 .

This should pin this repo to 20.04.1 moving forward. Once 20.04.3 is released we can rev this repo to 20.04.2 using this archive repo.

I'm not sure of a better way than being (N-1) to solve this since there is no static naming that remains the same. 

Maybe I could pull the latest release name dynamically somehow?